### PR TITLE
Utilize Action instead of Closure for configuration

### DIFF
--- a/src/main/groovy/com/matthewprenger/cursegradle/CurseArtifact.groovy
+++ b/src/main/groovy/com/matthewprenger/cursegradle/CurseArtifact.groovy
@@ -1,6 +1,7 @@
 package com.matthewprenger.cursegradle
 
 import com.google.gson.annotations.SerializedName
+import org.gradle.api.Action
 import org.gradle.api.Project
 
 import javax.annotation.Nullable
@@ -67,9 +68,9 @@ class CurseArtifact implements Serializable {
     @SerializedName("relations")
     CurseRelation curseRelations
 
-    void relations(@DelegatesTo(CurseRelation)Closure<?> configClosure) {
+    void relations(Action<CurseRelation> configClosure) {
         CurseRelation relation = new CurseRelation()
-        relation.with(configClosure)
+        configClosure.execute(relation)
         curseRelations = relation
     }
 
@@ -100,7 +101,7 @@ class CurseArtifact implements Serializable {
     }
 
     @Override
-    public String toString() {
+    String toString() {
         return "CurseArtifact{" +
                 "artifact=" + artifact +
                 ", changelogType=" + changelogType +

--- a/src/main/groovy/com/matthewprenger/cursegradle/CurseExtension.groovy
+++ b/src/main/groovy/com/matthewprenger/cursegradle/CurseExtension.groovy
@@ -1,5 +1,6 @@
 package com.matthewprenger.cursegradle
 
+import org.gradle.api.Action
 import org.gradle.api.Project
 
 class CurseExtension {
@@ -32,16 +33,16 @@ class CurseExtension {
      *
      * @param configClosure The configuration closure
      */
-    void project(@DelegatesTo(CurseProject) Closure<?> configClosure) {
+    void project(Action<CurseProject> configClosure) {
         CurseProject curseProject = new CurseProject()
-        curseProject.with(configClosure)
+        configClosure.execute(curseProject)
         if (curseProject.apiKey == null) {
             curseProject.apiKey = this.apiKey
         }
         curseProjects.add(curseProject)
     }
 
-    void options(Closure<?> configClosure) {
-        curseGradleOptions.with(configClosure)
+    void options(Action<Options> configClosure) {
+        configClosure.execute(curseGradleOptions)
     }
 }

--- a/src/main/groovy/com/matthewprenger/cursegradle/CurseProject.groovy
+++ b/src/main/groovy/com/matthewprenger/cursegradle/CurseProject.groovy
@@ -1,5 +1,7 @@
 package com.matthewprenger.cursegradle
 
+import org.gradle.api.Action
+
 import javax.annotation.Nullable
 
 import static com.matthewprenger.cursegradle.Util.check
@@ -58,7 +60,7 @@ class CurseProject {
     List<Object> gameVersionStrings = new ArrayList<>()
 
     @Nullable
-    Set<Closure<?>> curseRelations
+    Set<Action<CurseRelation>> curseRelations
 
     /**
      * Set the main artifact to upload
@@ -66,10 +68,10 @@ class CurseProject {
      * @param artifact The artifact
      * @param configClosure Optional configuration closure
      */
-    void mainArtifact(def artifact, @DelegatesTo(CurseArtifact)Closure<?> configClosure = null) {
+    void mainArtifact(def artifact, Action<CurseArtifact> configClosure = null) {
         CurseArtifact curseArtifact = new CurseArtifact()
         if (configClosure != null) {
-            curseArtifact.with(configClosure)
+            configClosure.execute(curseArtifact)
         }
         curseArtifact.artifact = artifact
         mainArtifact = curseArtifact
@@ -81,10 +83,10 @@ class CurseProject {
      * @param artifact The artifact
      * @param configClosure Optional configuration closure
      */
-    void addArtifact(def artifact, @DelegatesTo(CurseArtifact)Closure<?> configClosure = null) {
+    void addArtifact(def artifact, Action<CurseArtifact> configClosure = null) {
         CurseArtifact curseArtifact = new CurseArtifact()
         if (configClosure != null) {
-            curseArtifact.with(configClosure)
+            configClosure.execute(curseArtifact)
         }
         curseArtifact.artifact = artifact
         additionalArtifacts.add(curseArtifact)
@@ -104,7 +106,7 @@ class CurseProject {
      *
      * @param configureClosure The configuration closure
      */
-    void relations(@DelegatesTo(CurseRelation)Closure<?> configureClosure) {
+    void relations(Action<CurseRelation> configureClosure) {
         if (curseRelations == null) {
             curseRelations = new HashSet<>()
         }

--- a/src/main/groovy/com/matthewprenger/cursegradle/jsonresponse/CurseError.groovy
+++ b/src/main/groovy/com/matthewprenger/cursegradle/jsonresponse/CurseError.groovy
@@ -16,7 +16,7 @@ class CurseError {
     String errorMessage
 
     @Override
-    public String toString() {
+    String toString() {
         return "CurseError{" +
                "errorCode=" + errorCode +
                ", errorMessage='" + errorMessage + '\'' +


### PR DESCRIPTION
To quote the gradle wiki:
```
Gradle plugins written in any language should prefer the type Action<T> type in place of closures. Groovy closures and Kotlin lambdas are automatically mapped to arguments of that type.
```
([origin](https://docs.gradle.org/current/userguide/kotlin_dsl.html#groovy_closures_from_kotlin))

This makes using the plugin with kotlin slightly easier.
Though it is technically a breaking change, the API should remain the same for groovy users.