### PR TITLE
Make client and server game versions usable

### DIFF
--- a/src/main/groovy/com/matthewprenger/cursegradle/CurseVersions.groovy
+++ b/src/main/groovy/com/matthewprenger/cursegradle/CurseVersions.groovy
@@ -40,7 +40,8 @@ class CurseVersions {
                 if (
                         (type.slug.startsWith('minecraft') || type.slug == 'java' || type.slug == 'modloader') ||
                         (curseGradleOptions.bukkitIntegration && type.slug == 'bukkit') ||
-                        (curseGradleOptions.genericIntegration && type.slug == 'game')
+                        (curseGradleOptions.genericIntegration && type.slug == 'game') ||
+                        type.slug == 'client' || type.slug == 'server'
                 ) {
                     validVersionTypes.add(type.id)
                 }


### PR DESCRIPTION
CurseForge allows marking files usable for server and/or client  
It would be great, if it would be possible to publish files to CurseForge with the client and server game versions.